### PR TITLE
docs: add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # djc-core-html-parser
 
+[![PyPI - Version](https://img.shields.io/pypi/v/djc-core-html-parser)](https://pypi.org/project/djc-core-html-parser/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/djc-core-html-parser)](https://pypi.org/project/djc-core-html-parser/) [![PyPI - License](https://img.shields.io/pypi/l/djc-core-html-parser)](https://github.com/django-components/djc-core-html-parser/blob/master/LICENSE/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/djc-core-html-parser)](https://pypistats.org/packages/djc-core-html-parser) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/django-components/djc-core-html-parser/tests.yml)](https://github.com/django-components/djc-core-html-parser/actions/workflows/tests.yml)
+
 HTML parser used by [django-components](https://github.com/django-components/django-components). Written in Rust, exposed as a Python package with [maturin](https://www.maturin.rs/).
 
 This implementation was found to be 40-50x faster than our Python implementation, taking ~90ms to parse 5 MB of HTML.


### PR DESCRIPTION
This PR adds the same kind of badges to the README as we use for the django-components package:

<img width="839" alt="Screenshot 2025-03-22 at 12 06 45" src="https://github.com/user-attachments/assets/7aa15049-5f45-4e3c-8b16-d477c3b6876c" />
